### PR TITLE
update import type for EventRecord from @polkadot/api/interface

### DIFF
--- a/examples/plugins/output/mixed-methods/my_psp22.ts
+++ b/examples/plugins/output/mixed-methods/my_psp22.ts
@@ -14,7 +14,7 @@ import type BN from 'bn.js';
 import {ReturnNumber} from '@727-ventures/typechain-types';
 import {getTypeDescription} from './../shared/utils';
 // @ts-ignore
-import type {EventRecord} from "@polkadot/api/submittable";
+import type { EventRecord } from '@polkadot/types/interfaces'
 import {decodeEvents} from "../shared/utils";
 
 
@@ -47,7 +47,7 @@ export default class Methods {
 		amount: (string | number | BN),
 		__options: GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "mintTo", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "mintTo", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, "my_psp22");
 		}, [account, amount], __options);
 	}
@@ -68,7 +68,7 @@ export default class Methods {
 		data: Array<(number | string | BN)>,
 		__options: GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::transferFrom", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::transferFrom", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, "my_psp22");
 		}, [from, to, value, data], __options);
 	}
@@ -85,7 +85,7 @@ export default class Methods {
 		deltaValue: (string | number | BN),
 		__options: GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::decreaseAllowance", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::decreaseAllowance", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, "my_psp22");
 		}, [spender, deltaValue], __options);
 	}
@@ -126,7 +126,7 @@ export default class Methods {
 		value: (string | number | BN),
 		__options: GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::approve", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::approve", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, "my_psp22");
 		}, [spender, value], __options);
 	}
@@ -143,7 +143,7 @@ export default class Methods {
 		deltaValue: (string | number | BN),
 		__options: GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::increaseAllowance", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::increaseAllowance", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, "my_psp22");
 		}, [spender, deltaValue], __options);
 	}
@@ -177,7 +177,7 @@ export default class Methods {
 		data: Array<(number | string | BN)>,
 		__options: GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::transfer", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::transfer", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, "my_psp22");
 		}, [to, value, data], __options);
 	}
@@ -194,7 +194,7 @@ export default class Methods {
 		amount: (string | number | BN),
 		__options: GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22Mintable::mint", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22Mintable::mint", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, "my_psp22");
 		}, [account, amount], __options);
 	}

--- a/examples/plugins/output/mixed-methods/my_psp22.ts
+++ b/examples/plugins/output/mixed-methods/my_psp22.ts
@@ -14,7 +14,7 @@ import type BN from 'bn.js';
 import {ReturnNumber} from '@727-ventures/typechain-types';
 import {getTypeDescription} from './../shared/utils';
 // @ts-ignore
-import type { EventRecord } from '@polkadot/types/interfaces'
+import type { EventRecord } from '@polkadot/types/interfaces';
 import {decodeEvents} from "../shared/utils";
 
 

--- a/examples/plugins/output/tx-sign-and-send/my_psp22.ts
+++ b/examples/plugins/output/tx-sign-and-send/my_psp22.ts
@@ -8,7 +8,7 @@ import { txSignAndSend } from '@727-ventures/typechain-types';
 import type * as ArgumentTypes from '../types-arguments/my_psp22';
 import type BN from 'bn.js';
 // @ts-ignore
-import type { EventRecord } from '@polkadot/types/interfaces'
+import type { EventRecord } from '@polkadot/types/interfaces';
 import {decodeEvents} from "../shared/utils";
 
 

--- a/examples/plugins/output/tx-sign-and-send/my_psp22.ts
+++ b/examples/plugins/output/tx-sign-and-send/my_psp22.ts
@@ -8,7 +8,7 @@ import { txSignAndSend } from '@727-ventures/typechain-types';
 import type * as ArgumentTypes from '../types-arguments/my_psp22';
 import type BN from 'bn.js';
 // @ts-ignore
-import type {EventRecord} from "@polkadot/api/submittable";
+import type { EventRecord } from '@polkadot/types/interfaces'
 import {decodeEvents} from "../shared/utils";
 
 
@@ -38,7 +38,7 @@ export default class Methods {
 		amount: (string | number | BN),
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "mintTo", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "mintTo", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, "my_psp22");
 		}, [account, amount], __options);
 	}
@@ -58,7 +58,7 @@ export default class Methods {
 		data: Array<(number | string | BN)>,
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::transferFrom", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::transferFrom", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, "my_psp22");
 		}, [from, to, value, data], __options);
 	}
@@ -74,7 +74,7 @@ export default class Methods {
 		deltaValue: (string | number | BN),
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::decreaseAllowance", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::decreaseAllowance", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, "my_psp22");
 		}, [spender, deltaValue], __options);
 	}
@@ -88,7 +88,7 @@ export default class Methods {
 		owner: ArgumentTypes.AccountId,
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::balanceOf", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::balanceOf", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, "my_psp22");
 		}, [owner], __options);
 	}
@@ -100,7 +100,7 @@ export default class Methods {
 	"totalSupply" (
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::totalSupply", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::totalSupply", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, "my_psp22");
 		}, [], __options);
 	}
@@ -116,7 +116,7 @@ export default class Methods {
 		value: (string | number | BN),
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::approve", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::approve", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, "my_psp22");
 		}, [spender, value], __options);
 	}
@@ -132,7 +132,7 @@ export default class Methods {
 		deltaValue: (string | number | BN),
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::increaseAllowance", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::increaseAllowance", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, "my_psp22");
 		}, [spender, deltaValue], __options);
 	}
@@ -148,7 +148,7 @@ export default class Methods {
 		spender: ArgumentTypes.AccountId,
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::allowance", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::allowance", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, "my_psp22");
 		}, [owner, spender], __options);
 	}
@@ -166,7 +166,7 @@ export default class Methods {
 		data: Array<(number | string | BN)>,
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::transfer", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::transfer", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, "my_psp22");
 		}, [to, value, data], __options);
 	}
@@ -182,7 +182,7 @@ export default class Methods {
 		amount: (string | number | BN),
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22Mintable::mint", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22Mintable::mint", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, "my_psp22");
 		}, [account, amount], __options);
 	}

--- a/examples/psp22/out/mixed-methods/my_psp22.ts
+++ b/examples/psp22/out/mixed-methods/my_psp22.ts
@@ -14,7 +14,7 @@ import type BN from 'bn.js';
 import {ReturnNumber} from '@727-ventures/typechain-types';
 import {getTypeDescription} from './../shared/utils';
 // @ts-ignore
-import type {EventRecord} from "@polkadot/api/submittable";
+import type { EventRecord } from '@polkadot/types/interfaces'
 import {decodeEvents} from "../shared/utils";
 import DATA_TYPE_DESCRIPTIONS from '../data/my_psp22.json';
 import EVENT_DATA_TYPE_DESCRIPTIONS from '../event-data/my_psp22.json';
@@ -51,7 +51,7 @@ export default class Methods {
 		data: Array<(number | string | BN)>,
 		__options: GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::transfer", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::transfer", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [to, value, data], __options);
 	}
@@ -68,7 +68,7 @@ export default class Methods {
 		deltaValue: (string | number | BN),
 		__options: GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::decreaseAllowance", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::decreaseAllowance", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [spender, deltaValue], __options);
 	}
@@ -113,7 +113,7 @@ export default class Methods {
 		deltaValue: (string | number | BN),
 		__options: GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::increaseAllowance", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::increaseAllowance", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [spender, deltaValue], __options);
 	}
@@ -145,7 +145,7 @@ export default class Methods {
 		data: Array<(number | string | BN)>,
 		__options: GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::transferFrom", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::transferFrom", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [from, to, value, data], __options);
 	}
@@ -162,7 +162,7 @@ export default class Methods {
 		value: (string | number | BN),
 		__options: GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::approve", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::approve", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [spender, value], __options);
 	}
@@ -179,7 +179,7 @@ export default class Methods {
 		amount: (string | number | BN),
 		__options: GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22Mintable::mint", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22Mintable::mint", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [account, amount], __options);
 	}

--- a/examples/psp22/out/tx-sign-and-send/my_psp22.ts
+++ b/examples/psp22/out/tx-sign-and-send/my_psp22.ts
@@ -8,7 +8,7 @@ import { txSignAndSend } from '@727-ventures/typechain-types';
 import type * as ArgumentTypes from '../types-arguments/my_psp22';
 import type BN from 'bn.js';
 // @ts-ignore
-import type {EventRecord} from "@polkadot/api/submittable";
+import type { EventRecord } from '@polkadot/types/interfaces'
 import {decodeEvents} from "../shared/utils";
 import EVENT_DATA_TYPE_DESCRIPTIONS from '../event-data/my_psp22.json';
 
@@ -41,7 +41,7 @@ export default class Methods {
 		data: Array<(number | string | BN)>,
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::transfer", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::transfer", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [to, value, data], __options);
 	}
@@ -57,7 +57,7 @@ export default class Methods {
 		deltaValue: (string | number | BN),
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::decreaseAllowance", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::decreaseAllowance", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [spender, deltaValue], __options);
 	}
@@ -71,7 +71,7 @@ export default class Methods {
 		owner: ArgumentTypes.AccountId,
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::balanceOf", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::balanceOf", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [owner], __options);
 	}
@@ -87,7 +87,7 @@ export default class Methods {
 		spender: ArgumentTypes.AccountId,
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::allowance", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::allowance", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [owner, spender], __options);
 	}
@@ -103,7 +103,7 @@ export default class Methods {
 		deltaValue: (string | number | BN),
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::increaseAllowance", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::increaseAllowance", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [spender, deltaValue], __options);
 	}
@@ -115,7 +115,7 @@ export default class Methods {
 	"totalSupply" (
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::totalSupply", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::totalSupply", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [], __options);
 	}
@@ -135,7 +135,7 @@ export default class Methods {
 		data: Array<(number | string | BN)>,
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::transferFrom", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::transferFrom", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [from, to, value, data], __options);
 	}
@@ -151,7 +151,7 @@ export default class Methods {
 		value: (string | number | BN),
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::approve", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22::approve", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [spender, value], __options);
 	}
@@ -167,7 +167,7 @@ export default class Methods {
 		amount: (string | number | BN),
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22Mintable::mint", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp22Mintable::mint", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [account, amount], __options);
 	}

--- a/examples/psp34/out/mixed-methods/my_psp34.ts
+++ b/examples/psp34/out/mixed-methods/my_psp34.ts
@@ -14,7 +14,7 @@ import type BN from 'bn.js';
 import {ReturnNumber} from '@727-ventures/typechain-types';
 import {getTypeDescription} from './../shared/utils';
 // @ts-ignore
-import type {EventRecord} from "@polkadot/api/submittable";
+import type { EventRecord } from '@polkadot/types/interfaces';
 import {decodeEvents} from "../shared/utils";
 import DATA_TYPE_DESCRIPTIONS from '../data/my_psp34.json';
 import EVENT_DATA_TYPE_DESCRIPTIONS from '../event-data/my_psp34.json';
@@ -81,7 +81,7 @@ export default class Methods {
 		data: Array<(number | string | BN)>,
 		__options: GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::transfer", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::transfer", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [to, id, data], __options);
 	}
@@ -111,7 +111,7 @@ export default class Methods {
 		approved: boolean,
 		__options: GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::approve", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::approve", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [operator, id, approved], __options);
 	}
@@ -152,7 +152,7 @@ export default class Methods {
 		id: ArgumentTypes.Id,
 		__options: GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34Mintable::mint", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34Mintable::mint", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [account, id], __options);
 	}

--- a/examples/psp34/out/tx-sign-and-send/my_psp34.ts
+++ b/examples/psp34/out/tx-sign-and-send/my_psp34.ts
@@ -8,7 +8,7 @@ import { txSignAndSend } from '@727-ventures/typechain-types';
 import type * as ArgumentTypes from '../types-arguments/my_psp34';
 import type BN from 'bn.js';
 // @ts-ignore
-import type {EventRecord} from "@polkadot/api/submittable";
+import type { EventRecord } from '@polkadot/types/interfaces';
 import {decodeEvents} from "../shared/utils";
 import EVENT_DATA_TYPE_DESCRIPTIONS from '../event-data/my_psp34.json';
 
@@ -37,7 +37,7 @@ export default class Methods {
 		owner: ArgumentTypes.AccountId,
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::balanceOf", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::balanceOf", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [owner], __options);
 	}
@@ -55,7 +55,7 @@ export default class Methods {
 		id: ArgumentTypes.Id | null,
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::allowance", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::allowance", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [owner, operator, id], __options);
 	}
@@ -73,7 +73,7 @@ export default class Methods {
 		data: Array<(number | string | BN)>,
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::transfer", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::transfer", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [to, id, data], __options);
 	}
@@ -85,7 +85,7 @@ export default class Methods {
 	"collectionId" (
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::collectionId", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::collectionId", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [], __options);
 	}
@@ -103,7 +103,7 @@ export default class Methods {
 		approved: boolean,
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::approve", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::approve", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [operator, id, approved], __options);
 	}
@@ -117,7 +117,7 @@ export default class Methods {
 		id: ArgumentTypes.Id,
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::ownerOf", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::ownerOf", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [id], __options);
 	}
@@ -129,7 +129,7 @@ export default class Methods {
 	"totalSupply" (
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::totalSupply", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::totalSupply", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [], __options);
 	}
@@ -145,7 +145,7 @@ export default class Methods {
 		id: ArgumentTypes.Id,
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34Mintable::mint", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34Mintable::mint", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [account, id], __options);
 	}

--- a/examples/psp34_enumerable/out/mixed-methods/my_psp34_enumerable.ts
+++ b/examples/psp34_enumerable/out/mixed-methods/my_psp34_enumerable.ts
@@ -14,7 +14,7 @@ import type BN from 'bn.js';
 import {ReturnNumber} from '@727-ventures/typechain-types';
 import {getTypeDescription} from './../shared/utils';
 // @ts-ignore
-import type {EventRecord} from "@polkadot/api/submittable";
+import type { EventRecord } from '@polkadot/types/interfaces';
 import {decodeEvents} from "../shared/utils";
 import DATA_TYPE_DESCRIPTIONS from '../data/my_psp34_enumerable.json';
 import EVENT_DATA_TYPE_DESCRIPTIONS from '../event-data/my_psp34_enumerable.json';
@@ -86,7 +86,7 @@ export default class Methods {
 		approved: boolean,
 		__options: GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::approve", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::approve", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [operator, id, approved], __options);
 	}
@@ -122,7 +122,7 @@ export default class Methods {
 		data: Array<(number | string | BN)>,
 		__options: GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::transfer", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::transfer", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [to, id, data], __options);
 	}
@@ -152,7 +152,7 @@ export default class Methods {
 		id: ArgumentTypes.Id,
 		__options: GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34Mintable::mint", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34Mintable::mint", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [account, id], __options);
 	}
@@ -169,7 +169,7 @@ export default class Methods {
 		id: ArgumentTypes.Id,
 		__options: GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34Burnable::burn", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34Burnable::burn", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [account, id], __options);
 	}

--- a/examples/psp34_enumerable/out/tx-sign-and-send/my_psp34_enumerable.ts
+++ b/examples/psp34_enumerable/out/tx-sign-and-send/my_psp34_enumerable.ts
@@ -8,7 +8,7 @@ import { txSignAndSend } from '@727-ventures/typechain-types';
 import type * as ArgumentTypes from '../types-arguments/my_psp34_enumerable';
 import type BN from 'bn.js';
 // @ts-ignore
-import type {EventRecord} from "@polkadot/api/submittable";
+import type { EventRecord } from '@polkadot/types/interfaces';
 import {decodeEvents} from "../shared/utils";
 import EVENT_DATA_TYPE_DESCRIPTIONS from '../event-data/my_psp34_enumerable.json';
 
@@ -35,7 +35,7 @@ export default class Methods {
 	"collectionId" (
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::collectionId", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::collectionId", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [], __options);
 	}
@@ -47,7 +47,7 @@ export default class Methods {
 	"totalSupply" (
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::totalSupply", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::totalSupply", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [], __options);
 	}
@@ -61,7 +61,7 @@ export default class Methods {
 		owner: ArgumentTypes.AccountId,
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::balanceOf", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::balanceOf", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [owner], __options);
 	}
@@ -79,7 +79,7 @@ export default class Methods {
 		approved: boolean,
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::approve", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::approve", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [operator, id, approved], __options);
 	}
@@ -97,7 +97,7 @@ export default class Methods {
 		id: ArgumentTypes.Id | null,
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::allowance", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::allowance", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [owner, operator, id], __options);
 	}
@@ -115,7 +115,7 @@ export default class Methods {
 		data: Array<(number | string | BN)>,
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::transfer", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::transfer", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [to, id, data], __options);
 	}
@@ -129,7 +129,7 @@ export default class Methods {
 		id: ArgumentTypes.Id,
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::ownerOf", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34::ownerOf", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [id], __options);
 	}
@@ -145,7 +145,7 @@ export default class Methods {
 		id: ArgumentTypes.Id,
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34Mintable::mint", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34Mintable::mint", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [account, id], __options);
 	}
@@ -161,7 +161,7 @@ export default class Methods {
 		id: ArgumentTypes.Id,
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34Burnable::burn", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34Burnable::burn", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [account, id], __options);
 	}
@@ -175,7 +175,7 @@ export default class Methods {
 		index: (string | number | BN),
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34Enumerable::tokenByIndex", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34Enumerable::tokenByIndex", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [index], __options);
 	}
@@ -191,7 +191,7 @@ export default class Methods {
 		index: (string | number | BN),
 		__options ? : GasLimit,
 	){
-		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34Enumerable::ownersTokenByIndex", (events: EventRecord) => {
+		return txSignAndSend( this.__apiPromise, this.__nativeContract, this.__keyringPair, "psp34Enumerable::ownersTokenByIndex", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [owner, index], __options);
 	}

--- a/packages/typechain-polkadot/src/templates/mixed-methods.hbs
+++ b/packages/typechain-polkadot/src/templates/mixed-methods.hbs
@@ -14,7 +14,7 @@ import type BN from 'bn.js';
 import {ReturnNumber} from '@727-ventures/typechain-types';
 import {getTypeDescription} from './../shared/utils';
 // @ts-ignore
-import type {EventRecord} from "@polkadot/api/submittable";
+import type { EventRecord } from '@polkadot/types/interfaces';
 import {decodeEvents} from "../shared/utils";
 import DATA_TYPE_DESCRIPTIONS from '../data/{{{fileName}}}.json';
 import EVENT_DATA_TYPE_DESCRIPTIONS from '../event-data/{{{fileName}}}.json';
@@ -55,7 +55,7 @@ export default class Methods {
 	{{/each}}
 		__options: {{#if payable}}GasLimitAndRequiredValue{{else}}GasLimit{{/if}},
 	){{{buildReturnType this}}}{
-		return {{{buildReturn this}}} "{{{toCamelCaseForFunctions originalName}}}", {{#ifTx this}}(events: EventRecord) => {
+		return {{{buildReturn this}}} "{{{toCamelCaseForFunctions originalName}}}", {{#ifTx this}}(events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, {{/ifTx}}[{{#each args}}{{{name}}}{{#unless @last}}, {{/unless}}{{/each}}], __options{{{buildWrapper this}}});
 	}

--- a/packages/typechain-polkadot/src/templates/tx-sign-and-send.hbs
+++ b/packages/typechain-polkadot/src/templates/tx-sign-and-send.hbs
@@ -8,7 +8,7 @@ import { txSignAndSend } from '@727-ventures/typechain-types';
 import type * as ArgumentTypes from '../types-arguments/{{{fileName}}}';
 import type BN from 'bn.js';
 // @ts-ignore
-import type {EventRecord} from "@polkadot/api/submittable";
+import type { EventRecord } from '@polkadot/types/interfaces';
 import {decodeEvents} from "../shared/utils";
 import EVENT_DATA_TYPE_DESCRIPTIONS from '../event-data/{{{fileName}}}.json';
 {{#if additionalImports.length}}
@@ -45,7 +45,7 @@ export default class Methods {
 	{{/each}}
 		__options ? : {{#if payable}}GasLimitAndRequiredValue{{else}}GasLimit{{/if}},
 	){{{buildReturnType this}}}{
-		return {{{buildReturn this}}} "{{{toCamelCaseForFunctions originalName}}}", (events: EventRecord) => {
+		return {{{buildReturn this}}} "{{{toCamelCaseForFunctions originalName}}}", (events: EventRecord[]) => {
 			return decodeEvents(events, this.__nativeContract, EVENT_DATA_TYPE_DESCRIPTIONS);
 		}, [{{#each args}}{{{name}}}{{#unless @last}}, {{/unless}}{{/each}}], __options);
 	}

--- a/packages/typechain-types/dist/src/tx.d.ts
+++ b/packages/typechain-types/dist/src/tx.d.ts
@@ -4,7 +4,7 @@ import type { SubmittableExtrinsic } from '@polkadot/api/submittable/types';
 import type { KeyringPair } from '@polkadot/keyring/types';
 import type { Registry } from '@polkadot/types-codec/types';
 import type { ApiPromise, SubmittableResult } from "@polkadot/api";
-import type { EventRecord } from "@polkadot/api/submittable";
+import type { EventRecord } from '@polkadot/types/interfaces';
 type SignAndSendSuccessResponse = {
     from: string;
     txHash?: string;
@@ -19,7 +19,7 @@ type SignAndSendSuccessResponse = {
     };
 };
 export type { SignAndSendSuccessResponse, };
-export declare function txSignAndSend(nativeAPI: ApiPromise, nativeContract: ContractPromise, keyringPair: KeyringPair, title: string, eventHandler: (event: EventRecord[]) => {
+export declare function txSignAndSend(nativeAPI: ApiPromise, nativeContract: ContractPromise, keyringPair: KeyringPair, title: string, eventHandler: (event: EventRecord[][]) => {
     [index: string]: any;
 }, args?: readonly RequestArgumentType[], gasLimitAndValue?: GasLimitAndValue): Promise<SignAndSendSuccessResponse>;
 export declare function buildSubmittableExtrinsic(api: ApiPromise, nativeContract: ContractPromise, title: string, args?: readonly RequestArgumentType[], gasLimitAndValue?: GasLimitAndValue): SubmittableExtrinsic<"promise", import("@polkadot/types/types").ISubmittableResult>;
@@ -28,7 +28,7 @@ export declare function buildSubmittableExtrinsic(api: ApiPromise, nativeContrac
  * 	- https://polkadot.js.org/docs/api/cookbook/tx#how-do-i-get-the-decoded-enum-for-an-extrinsicfailed-event
  * 	- `@redspot/patract/buildTx`
  */
-export declare function _signAndSend(registry: Registry, extrinsic: SubmittableExtrinsic<'promise'>, signer: KeyringPair, eventHandler: (event: EventRecord[]) => {
+export declare function _signAndSend(registry: Registry, extrinsic: SubmittableExtrinsic<'promise'>, signer: KeyringPair, eventHandler: (event: EventRecord[][]) => {
     [index: string]: any;
 }): Promise<SignAndSendSuccessResponse>;
 //# sourceMappingURL=tx.d.ts.map

--- a/packages/typechain-types/src/tx.ts
+++ b/packages/typechain-types/src/tx.ts
@@ -33,7 +33,7 @@ import type { KeyringPair } from '@polkadot/keyring/types';
 import type { Registry } from '@polkadot/types-codec/types';
 import type {ApiPromise, SubmittableResult} from "@polkadot/api";
 // @ts-ignore
-import type {EventRecord} from "@polkadot/api/submittable";
+import type { EventRecord } from '@polkadot/types/interfaces';
 import {TypeTS} from "@727-ventures/typechain-polkadot-parser/src/types/TypeInfo";
 import {convertWeight} from "@polkadot/api-contract/base/util";
 import {Weight, WeightV2} from "@polkadot/types/interfaces";
@@ -62,7 +62,7 @@ export async function txSignAndSend(
 	nativeContract : ContractPromise,
 	keyringPair : KeyringPair,
 	title : string,
-	eventHandler : (event: EventRecord[]) => {
+	eventHandler : (event: EventRecord[][]) => {
 		[index: string]: any;
 	},
 	args ? : readonly RequestArgumentType[],
@@ -124,7 +124,7 @@ export async function _signAndSend(
 	registry: Registry,
 	extrinsic: SubmittableExtrinsic<'promise'>,
 	signer: KeyringPair,
-	eventHandler : (event: EventRecord[]) => {
+	eventHandler : (event: EventRecord[][]) => {
 		[index: string]: any;
 	},
 ): Promise<SignAndSendSuccessResponse> {


### PR DESCRIPTION
EventRecord has changed types in the latest polkadot api version. I've replicated the changes here to fix the typechain output