### PR TITLE
feat: support `ink!` v5 

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -154,8 +154,8 @@ Add the following to your `package.json`:
 	"@types/node": "^17.0.34",
 	"ts-node": "^10.7.0",
 	"typescript": "^4.6.4",
-	"@polkadot/api": "^10.8.1",
-	"@polkadot/api-contract": "^10.8.1",
+	"@polkadot/api": "^10.12.1",
+	"@polkadot/api-contract": "^10.12.1",
 	"@polkadot/keyring": "^10.4.2",
 	"@types/bn.js": "^5.1.0"
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,8 +13,8 @@ This directory contains examples of parsed contracts and pieces of advice how to
 	"@types/node": "^17.0.34",
 	"ts-node": "^10.7.0",
 	"typescript": "^4.6.4",
-	"@polkadot/api": "^10.8.1",
-	"@polkadot/api-contract": "^10.8.1",
+	"@polkadot/api": "^10.12.1",
+	"@polkadot/api-contract": "^10.12.1",
 	"@types/bn.js": "^5.1.0"
 }
 ```

--- a/examples/plugins/package.json
+++ b/examples/plugins/package.json
@@ -13,8 +13,8 @@
     "@types/node": "^17.0.34",
     "ts-node": "^10.7.0",
     "typescript": "^4.6.4",
-    "@polkadot/api": "^10.8.1",
-    "@polkadot/api-contract": "^10.8.1",
+    "@polkadot/api": "^10.12.1",
+    "@polkadot/api-contract": "^10.12.1",
     "@types/bn.js": "^5.1.0"
   },
   "author": "Varex Silver",

--- a/examples/psp22/package.json
+++ b/examples/psp22/package.json
@@ -13,8 +13,8 @@
     "@types/node": "^18.8.0",
     "ts-node": "^10.7.0",
     "typescript": "^4.6.4",
-    "@polkadot/api": "^10.8.1",
-    "@polkadot/api-contract": "^10.8.1",
+    "@polkadot/api": "^10.12.1",
+    "@polkadot/api-contract": "^10.12.1",
     "@types/bn.js": "^5.1.0"
   },
   "author": "Supercolony-net",

--- a/examples/psp34/package.json
+++ b/examples/psp34/package.json
@@ -13,8 +13,8 @@
     "@types/node": "^18.8.0",
     "ts-node": "^10.7.0",
     "typescript": "^4.9.5",
-    "@polkadot/api": "^10.8.1",
-    "@polkadot/api-contract": "^10.8.1",
+    "@polkadot/api": "^10.12.1",
+    "@polkadot/api-contract": "^10.12.1",
     "@types/bn.js": "^5.1.1"
   },
   "author": "Supercolony-net",

--- a/examples/psp34_enumerable/package.json
+++ b/examples/psp34_enumerable/package.json
@@ -13,8 +13,8 @@
     "@types/node": "^18.8.0",
     "ts-node": "^10.7.0",
     "typescript": "^4.6.4",
-    "@polkadot/api": "^10.8.1",
-    "@polkadot/api-contract": "^10.8.1",
+    "@polkadot/api": "^10.12.1",
+    "@polkadot/api-contract": "^10.12.1",
     "@types/bn.js": "^5.1.0"
   },
   "author": "Supercolony-net",

--- a/packages/typechain-polkadot-parser/package.json
+++ b/packages/typechain-polkadot-parser/package.json
@@ -16,8 +16,8 @@
   },
   "homepage": "https://github.com/727-ventures/typechain-polkadot#readme",
   "dependencies": {
-    "@polkadot/api": "^10.8.1",
-    "@polkadot/api-contract": "^10.8.1",
+    "@polkadot/api": "^10.12.1",
+    "@polkadot/api-contract": "^10.12.1",
     "@types/bn.js": "^5.1.0",
     "@types/node": "^18.0.3",
     "typescript": "^4.7.4",

--- a/packages/typechain-polkadot/package.json
+++ b/packages/typechain-polkadot/package.json
@@ -22,8 +22,8 @@
   "engineStrict": true,
   "dependencies": {
     "@727-ventures/typechain-polkadot-parser": "1.0.2",
-    "@polkadot/api": "^10.8.1",
-    "@polkadot/api-contract": "^10.8.1",
+    "@polkadot/api": "^10.12.1",
+    "@polkadot/api-contract": "^10.12.1",
     "@polkadot/keyring": "^12.2.2",
     "@types/fs-extra": "^9.0.13",
     "@types/node": "^18.11.18",

--- a/packages/typechain-types/package.json
+++ b/packages/typechain-types/package.json
@@ -24,8 +24,8 @@
   "main": "dist/index.js",
   "homepage": "https://github.com/727-ventures/typechain-polkadot#readme",
   "dependencies": {
-    "@polkadot/api": "^10.8.1",
-    "@polkadot/api-contract": "^10.8.1",
+    "@polkadot/api": "^10.12.1",
+    "@polkadot/api-contract": "^10.12.1",
     "@types/bn.js": "^5.1.0",
     "@types/node": "^18.0.3",
     "camelcase": "^6.3.0"


### PR DESCRIPTION
bump to the latest pjs `api` and `api-contract` release to support inkv5 with contract metadata version 5